### PR TITLE
Add unit tests for task store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@element-plus/icons-vue": "^2.3.1",

--- a/tests/useTaskStore.spec.ts
+++ b/tests/useTaskStore.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useTaskStore } from '../src/stores/useTaskStore'
+
+const isoRegex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+
+describe('useTaskStore', () => {
+  let store: ReturnType<typeof useTaskStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    const storage: Record<string, string> = {}
+    ;(globalThis as any).localStorage = {
+      getItem: (key: string) => (key in storage ? storage[key] : null),
+      setItem: (key: string, value: string) => {
+        storage[key] = value
+      },
+      removeItem: (key: string) => {
+        delete storage[key]
+      },
+      clear: () => {
+        Object.keys(storage).forEach(k => delete storage[k])
+      },
+      key: (index: number) => Object.keys(storage)[index] || null,
+      get length() {
+        return Object.keys(storage).length
+      }
+    } as Storage
+    store = useTaskStore()
+  })
+
+  it('adds a task', () => {
+    const due = new Date('2025-05-01T10:30:00Z').toISOString()
+    store.add({ title: 'task', status: '新建', dueDate: due })
+    expect(store.list).toHaveLength(1)
+    expect(store.list[0]).toMatchObject({ title: 'task', status: '新建', dueDate: due })
+  })
+
+  it('updates a task', () => {
+    store.add({ title: 'old', status: '新建' })
+    const id = store.list[0].id
+    const newDue = new Date('2025-06-01T11:30:00Z').toISOString()
+    store.update(id, { title: 'new', status: '处理中', dueDate: newDue })
+    expect(store.list[0]).toMatchObject({ title: 'new', status: '处理中', dueDate: newDue })
+  })
+
+  it('removes a task', () => {
+    store.add({ title: 'a', status: '新建' })
+    store.add({ title: 'b', status: '新建' })
+    const id = store.list[0].id
+    store.remove(id)
+    expect(store.list).toHaveLength(1)
+    expect(store.list[0].title).toBe('b')
+  })
+
+  it('stores dueDate as ISO string', () => {
+    const due = new Date('2025-07-01T12:00:00Z').toISOString()
+    store.add({ title: 'date test', status: '新建', dueDate: due })
+    expect(store.list[0].dueDate).toMatch(isoRegex)
+  })
+})
+


### PR DESCRIPTION
## Summary
- add Vitest tests covering add/update/remove and dueDate formatting in task store
- expose `npm test` script in package.json
- ignore node_modules with `.gitignore`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a42bf9cbd0832ebdd8fb3faaf218bb