### PR TITLE
Rename task list to maintenance plans

### DIFF
--- a/src/components/NavigationMenu.vue
+++ b/src/components/NavigationMenu.vue
@@ -25,9 +25,9 @@
       <el-icon><House /></el-icon>
       <span>首页</span>
     </el-menu-item>
-    <el-menu-item index="/tasks">
+    <el-menu-item index="/maintenance-plans">
       <el-icon><Tickets /></el-icon>
-      <span>任务</span>
+      <span>维保计划</span>
     </el-menu-item>
     <el-menu-item index="/orders">
       <el-icon><Suitcase /></el-icon>
@@ -82,7 +82,7 @@ import { House, Tickets, Suitcase, Monitor, Search, Box, Bell, Reading, Message,
 
 // Access the current route so that `el-menu` can highlight the
 // appropriate menu item.  The `route.path` property holds the
-// current pathname (e.g. "/tasks").
+// current pathname (e.g. "/maintenance-plans").
 const route = useRoute()
 </script>
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,9 +20,9 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/HomeView.vue')
   },
   {
-    path: '/tasks',
-    name: 'Tasks',
-    component: () => import('@/views/TaskList.vue')
+    path: '/maintenance-plans',
+    name: 'MaintenancePlans',
+    component: () => import('@/views/MaintenancePlanList.vue')
   },
   {
     path: '/orders',

--- a/src/views/MaintenancePlanList.vue
+++ b/src/views/MaintenancePlanList.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <h2>任务列表</h2>
-    <!-- Add new task button -->
-    <el-button type="primary" class="mb-2" @click="openAdd">＋ 添加任务</el-button>
+    <h2>维保计划列表</h2>
+    <!-- Add new maintenance plan button -->
+    <el-button type="primary" class="mb-2" @click="openAdd">＋ 添加维保计划</el-button>
     <!-- Filter controls -->
     <div class="filters">
       <el-input
@@ -49,7 +49,7 @@
       </el-select>
       <el-button size="default" @click="resetFilters">重置</el-button>
     </div>
-    <!-- Tasks table -->
+    <!-- Maintenance plans table -->
     <el-table :data="filteredTasks" stripe style="width: 100%;">
       <el-table-column prop="id" label="ID" width="60" />
       <el-table-column prop="title" label="标题" />
@@ -66,8 +66,8 @@
         </template>
       </el-table-column>
     </el-table>
-    <!-- Add task dialog -->
-    <el-dialog v-model="addDialogVisible" title="添加任务" width="500px">
+    <!-- Add maintenance plan dialog -->
+    <el-dialog v-model="addDialogVisible" title="添加维保计划" width="500px">
       <el-form :model="newTask" label-width="80px">
         <el-form-item label="标题">
           <el-input v-model="newTask.title" />
@@ -105,8 +105,8 @@
         <el-button type="primary" @click="addTask">确认</el-button>
       </template>
     </el-dialog>
-    <!-- Task details dialog -->
-    <el-dialog v-model="detailDialogVisible" title="任务详情" width="500px">
+    <!-- Maintenance plan details dialog -->
+    <el-dialog v-model="detailDialogVisible" title="维保计划详情" width="500px">
       <template v-if="selectedTask">
         <el-form :model="selectedTask" label-width="80px">
           <el-form-item label="标题">
@@ -155,7 +155,7 @@ import { useTaskStore, Task } from '@/stores/useTaskStore'
 
 const store = useTaskStore()
 
-// Load tasks from storage when the component is mounted
+// Load maintenance plans from storage when the component is mounted
 onMounted(() => {
   store.load()
 })
@@ -172,7 +172,7 @@ const dueEnd = ref<Date | null>(null)
 const sortBy = ref('id-desc')
 
 /**
- * Compute a filtered and sorted copy of the task list.  The filters
+ * Compute a filtered and sorted copy of the maintenance plan list.  The filters
  * mirror those in the original IDC PWA implementation: keyword search,
  * status filter, location search, recurrence filter and due date range.
  */


### PR DESCRIPTION
## Summary
- update navigation menu to link to maintenance plans
- rename tasks route and component to maintenance plans
- rename TaskList view to MaintenancePlanList with updated text

## Testing
- `npx --yes vitest`

------
https://chatgpt.com/codex/tasks/task_e_68a68478af74832e98133b1fdac75abe