### PR TITLE
feat: add recurring task scheduling

### DIFF
--- a/src/stores/useTaskStore.ts
+++ b/src/stores/useTaskStore.ts
@@ -61,6 +61,49 @@ export const useTaskStore = defineStore('tasks', {
       localStorage.setItem('idc-tasks', JSON.stringify(this.list))
     },
     /**
+     * When a recurring task is completed schedule the next occurrence.
+     * A new task with the same details but a later dueDate is inserted
+     * unless one already exists. Supported recurrences are 每日/每周/每月.
+     */
+    scheduleNext(task: Task) {
+      if (task.status !== '已完成' || !task.recurrence || !task.dueDate) {
+        return
+      }
+      const current = new Date(task.dueDate)
+      const next = new Date(current)
+      switch (task.recurrence) {
+        case '每日':
+          next.setDate(current.getDate() + 1)
+          break
+        case '每周':
+          next.setDate(current.getDate() + 7)
+          break
+        case '每月':
+          next.setMonth(current.getMonth() + 1)
+          break
+        default:
+          return
+      }
+      const due = next.toISOString()
+      const exists = this.list.some(t => t.title === task.title && t.dueDate === due)
+      if (exists) {
+        return
+      }
+      const newTask: Task = {
+        id: this.nextId++,
+        title: task.title,
+        status: '新建',
+        location: task.location,
+        recurrence: task.recurrence,
+        dueDate: due,
+        createdAt: new Date().toISOString(),
+        description: task.description,
+        synced: false
+      }
+      this.list.push(newTask)
+      this.save()
+    },
+    /**
      * Add a new task.  The id, creation timestamp and synced flag are
      * automatically filled in.
      */
@@ -72,6 +115,7 @@ export const useTaskStore = defineStore('tasks', {
         ...taskData
       }
       this.list.push(task)
+      this.scheduleNext(task)
       this.save()
     },
     /**
@@ -82,6 +126,7 @@ export const useTaskStore = defineStore('tasks', {
       const idx = this.list.findIndex(t => t.id === id)
       if (idx !== -1) {
         this.list[idx] = { ...this.list[idx], ...data }
+        this.scheduleNext(this.list[idx])
         this.save()
       }
     },

--- a/tests/useTaskStore.spec.ts
+++ b/tests/useTaskStore.spec.ts
@@ -58,5 +58,25 @@ describe('useTaskStore', () => {
     store.add({ title: 'date test', status: '新建', dueDate: due })
     expect(store.list[0].dueDate).toMatch(isoRegex)
   })
+
+  it('schedules next task for completed recurring items', () => {
+    const due = new Date('2025-08-01T08:00:00Z').toISOString()
+    store.add({ title: 'rec', status: '已完成', recurrence: '每日', dueDate: due })
+    expect(store.list).toHaveLength(2)
+    const nextDue = new Date('2025-08-02T08:00:00Z').toISOString()
+    const next = store.list.find(t => t.dueDate === nextDue)
+    expect(next).toBeTruthy()
+    expect(next?.status).toBe('新建')
+  })
+
+  it('avoids duplicate scheduled tasks', () => {
+    const due = new Date('2025-09-01T08:00:00Z').toISOString()
+    store.add({ title: 'dup', status: '已完成', recurrence: '每日', dueDate: due })
+    // call scheduleNext again to simulate repeated completion
+    store.scheduleNext(store.list[0])
+    const nextDue = new Date('2025-09-02T08:00:00Z').toISOString()
+    const occurrences = store.list.filter(t => t.dueDate === nextDue)
+    expect(occurrences.length).toBe(1)
+  })
 })
 


### PR DESCRIPTION
## Summary
- add `scheduleNext` to compute next due date for recurring tasks and persist new tasks
- invoke `scheduleNext` on add/update to keep recurring tasks active
- cover recurring scheduling and duplicate prevention in task store tests

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6847a6d6c832e9a9f614eeae67fe4