### PR TITLE
feat: add equipment specialty field to orders

### DIFF
--- a/src/stores/useOrderStore.ts
+++ b/src/stores/useOrderStore.ts
@@ -5,6 +5,7 @@ export interface Order {
   title: string
   priority: '高' | '中' | '低'
   reporter: string
+  specialty: '暖通' | '配电' | '消防弱电'
   assignee?: string
   status: '新建' | '处理中' | '已完成'
   startDate?: string

--- a/src/views/OrderList.vue
+++ b/src/views/OrderList.vue
@@ -28,6 +28,7 @@
       <el-table-column prop="title" label="标题" />
       <el-table-column prop="priority" label="优先级" width="80" />
       <el-table-column prop="reporter" label="上报人" />
+      <el-table-column prop="specialty" label="设备专业" />
       <el-table-column prop="assignee" label="处理人" />
       <el-table-column prop="status" label="状态" width="90" />
       <el-table-column prop="startDate" label="开始日期" />
@@ -55,6 +56,13 @@
         </el-form-item>
         <el-form-item label="上报人">
           <el-input v-model="newOrder.reporter" />
+        </el-form-item>
+        <el-form-item label="设备专业">
+          <el-select v-model="newOrder.specialty">
+            <el-option label="暖通" value="暖通" />
+            <el-option label="配电" value="配电" />
+            <el-option label="消防弱电" value="消防弱电" />
+          </el-select>
         </el-form-item>
         <el-form-item label="处理人">
           <el-input v-model="newOrder.assignee" />
@@ -97,6 +105,13 @@
           </el-form-item>
           <el-form-item label="上报人">
             <el-input v-model="selectedOrder.reporter" />
+          </el-form-item>
+          <el-form-item label="设备专业">
+            <el-select v-model="selectedOrder.specialty">
+              <el-option label="暖通" value="暖通" />
+              <el-option label="配电" value="配电" />
+              <el-option label="消防弱电" value="消防弱电" />
+            </el-select>
           </el-form-item>
           <el-form-item label="处理人">
             <el-input v-model="selectedOrder.assignee" />
@@ -180,6 +195,7 @@ const newOrder = reactive<Omit<Order, 'id' | 'createdAt' | 'synced'>>({
   title: '',
   priority: '中',
   reporter: '',
+  specialty: '暖通',
   assignee: '',
   status: '新建',
   startDate: '',
@@ -188,7 +204,7 @@ const newOrder = reactive<Omit<Order, 'id' | 'createdAt' | 'synced'>>({
 })
 
 function openAdd() {
-  Object.assign(newOrder, { title: '', priority: '中', reporter: '', assignee: '', status: '新建', startDate: '', endDate: '', description: '' })
+  Object.assign(newOrder, { title: '', priority: '中', reporter: '', specialty: '暖通', assignee: '', status: '新建', startDate: '', endDate: '', description: '' })
   addDialogVisible.value = true
 }
 
@@ -198,6 +214,7 @@ function addOrder() {
     title: newOrder.title,
     priority: newOrder.priority,
     reporter: newOrder.reporter,
+    specialty: newOrder.specialty,
     assignee: newOrder.assignee || undefined,
     status: newOrder.status,
     startDate: newOrder.startDate || undefined,
@@ -221,6 +238,7 @@ function updateOrder() {
       title: selectedOrder.value.title,
       priority: selectedOrder.value.priority,
       reporter: selectedOrder.value.reporter,
+      specialty: selectedOrder.value.specialty,
       assignee: selectedOrder.value.assignee,
       status: selectedOrder.value.status,
       startDate: selectedOrder.value.startDate,


### PR DESCRIPTION
## Summary
- add `specialty` field to order store and interface
- capture equipment specialty in new/edit dialogs and show in list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6863de2e8832eb2a19cf67522c865