### PR TITLE
feat: add inspection editing

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -40,6 +40,11 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/InspectionList.vue')
   },
   {
+    path: '/inspections/:id/edit',
+    name: 'InspectionEdit',
+    component: () => import('@/views/InspectionForm.vue')
+  },
+  {
     path: '/assets',
     name: 'Assets',
     component: () => import('@/views/AssetList.vue')

--- a/src/stores/useInspectionStore.ts
+++ b/src/stores/useInspectionStore.ts
@@ -1,0 +1,62 @@
+import { defineStore } from 'pinia'
+
+export interface InspectionItem {
+  id: number
+  content: string
+  status: '正常' | '异常'
+}
+
+export interface Inspection {
+  id: number
+  title: string
+  inspector: string
+  date: string
+  items: InspectionItem[]
+  abnormal: number
+}
+
+const STORAGE_KEY = 'idc-inspections'
+
+export const useInspectionStore = defineStore('inspection', {
+  state: () => ({
+    list: [] as Inspection[]
+  }),
+  actions: {
+    load() {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (raw) {
+        this.list = JSON.parse(raw)
+      } else {
+        // seed with demo data
+        this.list = [
+          {
+            id: 1,
+            title: '机房A巡检',
+            inspector: '张三',
+            date: new Date().toISOString().slice(0, 10),
+            items: [
+              { id: 1, content: 'UPS电源', status: '正常' },
+              { id: 2, content: '空调温度', status: '异常' },
+              { id: 3, content: '消防系统', status: '正常' }
+            ],
+            abnormal: 1
+          }
+        ]
+        this.save()
+      }
+    },
+    save() {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.list))
+    },
+    getById(id: number) {
+      return this.list.find(i => i.id === id)
+    },
+    update(id: number, data: Partial<Inspection>) {
+      const idx = this.list.findIndex(i => i.id === id)
+      if (idx !== -1) {
+        this.list[idx] = { ...this.list[idx], ...data }
+        this.save()
+      }
+    }
+  }
+})

--- a/src/views/InspectionForm.vue
+++ b/src/views/InspectionForm.vue
@@ -1,0 +1,77 @@
+<template>
+  <div v-if="inspection">
+    <h2>编辑巡检</h2>
+    <el-form :model="inspection" label-width="80px">
+      <el-form-item label="标题">
+        <el-input v-model="inspection.title" />
+      </el-form-item>
+      <el-form-item label="巡检人">
+        <el-input v-model="inspection.inspector" />
+      </el-form-item>
+      <el-form-item label="日期">
+        <el-date-picker v-model="inspection.date" type="date" />
+      </el-form-item>
+    </el-form>
+    <el-table :data="inspection.items" stripe style="width: 100%" class="mt-2">
+      <el-table-column prop="content" label="项目" />
+      <el-table-column prop="status" label="状态" width="120">
+        <template #default="scope">
+          <el-select v-model="scope.row.status" @change="recalc">
+            <el-option label="正常" value="正常" />
+            <el-option label="异常" value="异常" />
+          </el-select>
+        </template>
+      </el-table-column>
+    </el-table>
+    <div class="mt-2">异常数：{{ inspection.abnormal }}</div>
+    <el-button type="primary" class="mt-2" @click="save">保存</el-button>
+    <el-button class="mt-2" @click="router.back()">返回</el-button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
+import { useInspectionStore, Inspection } from '@/stores/useInspectionStore'
+
+const store = useInspectionStore()
+const route = useRoute()
+const router = useRouter()
+const inspection = ref<Inspection | null>(null)
+
+onMounted(() => {
+  store.load()
+  const id = Number(route.params.id)
+  const record = store.getById(id)
+  if (record) {
+    inspection.value = JSON.parse(JSON.stringify(record))
+  } else {
+    router.push('/inspections')
+  }
+})
+
+function recalc() {
+  if (inspection.value) {
+    inspection.value.abnormal = inspection.value.items.filter(i => i.status === '异常').length
+  }
+}
+
+function save() {
+  if (inspection.value) {
+    recalc()
+    store.update(inspection.value.id, inspection.value)
+    ElMessage.success('已更新')
+    router.push('/inspections')
+  }
+}
+</script>
+
+<style scoped>
+h2 {
+  margin-bottom: 12px;
+}
+.mt-2 {
+  margin-top: 12px;
+}
+</style>

--- a/src/views/InspectionList.vue
+++ b/src/views/InspectionList.vue
@@ -1,15 +1,40 @@
 <template>
   <div>
-    <h2>巡检</h2>
-    <p>巡检模块正在开发中。</p>
+    <h2>巡检记录</h2>
+    <el-table :data="store.list" stripe style="width: 100%">
+      <el-table-column prop="id" label="ID" width="60" />
+      <el-table-column prop="title" label="标题" />
+      <el-table-column prop="inspector" label="巡检人" />
+      <el-table-column prop="date" label="日期" />
+      <el-table-column prop="abnormal" label="异常数" width="80" />
+      <el-table-column label="操作" width="120">
+        <template #default="scope">
+          <el-button size="small" @click="edit(scope.row.id)">编辑</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
   </div>
 </template>
 
 <script setup lang="ts">
-// TODO: implement inspection list and detail pages.  This placeholder
-// provides context while the feature is under development.
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useInspectionStore } from '@/stores/useInspectionStore'
+
+const store = useInspectionStore()
+const router = useRouter()
+
+onMounted(() => {
+  store.load()
+})
+
+function edit(id: number) {
+  router.push(`/inspections/${id}/edit`)
+}
 </script>
 
 <style scoped>
-h2 { margin-bottom: 12px; }
+h2 {
+  margin-bottom: 12px;
+}
 </style>


### PR DESCRIPTION
## Summary
- implement inspection store with persistence and demo data
- add inspection list with edit action and route
- create inspection form to update items and recompute abnormal count

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a688107bb0832e98e98beca2645277