### PR TITLE
feat: add maintainer signature field to orders

### DIFF
--- a/src/stores/useOrderStore.ts
+++ b/src/stores/useOrderStore.ts
@@ -10,6 +10,7 @@ export interface Order {
   startDate?: string
   endDate?: string
   description?: string
+  maintainerSignature?: string
   createdAt: string
   synced: boolean
 }

--- a/src/views/OrderList.vue
+++ b/src/views/OrderList.vue
@@ -33,6 +33,7 @@
       <el-table-column prop="startDate" label="开始日期" />
       <el-table-column prop="endDate" label="结束日期" />
       <el-table-column prop="description" label="描述" />
+      <el-table-column prop="maintainerSignature" label="维修人签认" />
       <el-table-column label="操作" width="160">
         <template #default="scope">
           <el-button size="small" @click="openDetails(scope.row)">详情</el-button>
@@ -75,6 +76,9 @@
         <el-form-item label="描述">
           <el-input type="textarea" v-model="newOrder.description" />
         </el-form-item>
+        <el-form-item label="维修人签认">
+          <el-input v-model="newOrder.maintainerSignature" />
+        </el-form-item>
       </el-form>
       <template #footer>
         <el-button @click="addDialogVisible = false">取消</el-button>
@@ -116,6 +120,9 @@
           </el-form-item>
           <el-form-item label="描述">
             <el-input type="textarea" v-model="selectedOrder.description" />
+          </el-form-item>
+          <el-form-item label="维修人签认">
+            <el-input v-model="selectedOrder.maintainerSignature" />
           </el-form-item>
         </el-form>
       </template>
@@ -184,11 +191,12 @@ const newOrder = reactive<Omit<Order, 'id' | 'createdAt' | 'synced'>>({
   status: '新建',
   startDate: '',
   endDate: '',
-  description: ''
+  description: '',
+  maintainerSignature: ''
 })
 
 function openAdd() {
-  Object.assign(newOrder, { title: '', priority: '中', reporter: '', assignee: '', status: '新建', startDate: '', endDate: '', description: '' })
+  Object.assign(newOrder, { title: '', priority: '中', reporter: '', assignee: '', status: '新建', startDate: '', endDate: '', description: '', maintainerSignature: '' })
   addDialogVisible.value = true
 }
 
@@ -202,7 +210,8 @@ function addOrder() {
     status: newOrder.status,
     startDate: newOrder.startDate || undefined,
     endDate: newOrder.endDate || undefined,
-    description: newOrder.description || undefined
+    description: newOrder.description || undefined,
+    maintainerSignature: newOrder.maintainerSignature || undefined
   })
   addDialogVisible.value = false
 }
@@ -222,10 +231,11 @@ function updateOrder() {
       priority: selectedOrder.value.priority,
       reporter: selectedOrder.value.reporter,
       assignee: selectedOrder.value.assignee,
-      status: selectedOrder.value.status,
-      startDate: selectedOrder.value.startDate,
-      endDate: selectedOrder.value.endDate,
-      description: selectedOrder.value.description
+    status: selectedOrder.value.status,
+    startDate: selectedOrder.value.startDate,
+    endDate: selectedOrder.value.endDate,
+    description: selectedOrder.value.description,
+    maintainerSignature: selectedOrder.value.maintainerSignature
     })
   }
   detailDialogVisible.value = false


### PR DESCRIPTION
## Summary
- add optional `maintainerSignature` property to `Order`
- capture and display maintainer signature in order list, add dialog, and detail view

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a68640642c832e9ec74bb5dddc96f8