### PR TITLE
feat: add asset history dialog

### DIFF
--- a/src/components/AssetHistoryDialog.vue
+++ b/src/components/AssetHistoryDialog.vue
@@ -1,0 +1,27 @@
+<template>
+  <el-dialog
+    :model-value="visible"
+    @update:modelValue="emit('update:visible', $event)"
+    title="借用记录"
+  >
+    <el-table :data="logs" style="width: 100%">
+      <el-table-column prop="borrowerId" label="借用人" />
+      <el-table-column prop="borrowTime" label="借出时间" />
+      <el-table-column prop="returnTime" label="归还时间" />
+    </el-table>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue'
+interface Log {
+  borrowerId: string
+  borrowTime: string
+  returnTime?: string
+}
+
+const props = defineProps<{ logs: Log[]; visible: boolean }>()
+const emit = defineEmits<{ (e: 'update:visible', value: boolean): void }>()
+
+const { logs, visible } = toRefs(props)
+</script>

--- a/src/views/AssetList.vue
+++ b/src/views/AssetList.vue
@@ -1,14 +1,94 @@
 <template>
   <div>
     <h2>资产管理</h2>
-    <p>资产管理模块正在开发中。</p>
+    <el-table :data="assets" style="width: 100%">
+      <el-table-column prop="id" label="ID" width="60" />
+      <el-table-column prop="name" label="名称" />
+      <el-table-column prop="status" label="状态" width="80" />
+      <el-table-column label="操作" width="220">
+        <template #default="scope">
+          <el-button size="small" @click="openHistory(scope.row)">记录</el-button>
+          <el-button
+            size="small"
+            type="primary"
+            v-if="scope.row.status === 'available'"
+            @click="borrowAsset(scope.row)"
+          >借出</el-button>
+          <el-button
+            size="small"
+            type="success"
+            v-else
+            @click="returnAsset(scope.row)"
+          >归还</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+    <AssetHistoryDialog
+      v-if="currentAsset"
+      v-model:visible="historyVisible"
+      :logs="currentAsset.logs"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-// Placeholder for asset management functionality.
+import { ref } from 'vue'
+import { ElMessageBox } from 'element-plus'
+import AssetHistoryDialog from '@/components/AssetHistoryDialog.vue'
+
+interface Log {
+  borrowerId: string
+  borrowTime: string
+  returnTime?: string
+}
+
+interface Asset {
+  id: number
+  name: string
+  status: 'available' | 'borrowed'
+  borrowerId?: string
+  logs: Log[]
+}
+
+const assets = ref<Asset[]>([
+  { id: 1, name: '服务器', status: 'available', logs: [] },
+  { id: 2, name: '交换机', status: 'available', logs: [] }
+])
+
+const historyVisible = ref(false)
+const currentAsset = ref<Asset | null>(null)
+
+function openHistory(asset: Asset) {
+  currentAsset.value = asset
+  historyVisible.value = true
+}
+
+async function borrowAsset(asset: Asset) {
+  const { value: borrowerId } = await ElMessageBox.prompt('请输入借用人ID', '借出资产', {
+    confirmButtonText: '确定',
+    cancelButtonText: '取消'
+  })
+  asset.status = 'borrowed'
+  asset.borrowerId = borrowerId
+  asset.logs.push({
+    borrowerId,
+    borrowTime: new Date().toLocaleString(),
+    returnTime: ''
+  })
+}
+
+function returnAsset(asset: Asset) {
+  asset.status = 'available'
+  const log = [...asset.logs].reverse().find(l => !l.returnTime)
+  if (log) {
+    log.returnTime = new Date().toLocaleString()
+  }
+  asset.borrowerId = undefined
+}
 </script>
 
 <style scoped>
-h2 { margin-bottom: 12px; }
+h2 {
+  margin-bottom: 12px;
+}
 </style>


### PR DESCRIPTION
## Summary
- add AssetHistoryDialog component to display asset borrow history
- implement asset history button and borrow/return log updates

## Testing
- `npx -y vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a688321710832eae8770946cf39a1d